### PR TITLE
Working GH Action to build/update/preview

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,0 +1,27 @@
+on: [pull_request]
+jobs:
+  preview:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 🏗 Setup repo
+        uses: actions/checkout@v3
+
+      - name: 🏗 Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18.x
+          cache: yarn
+
+      - name: 🏗 Setup EAS
+        uses: expo/expo-github-action@v8
+        with:
+          expo-version: latest
+          token: ${{ secrets.EXPO_TOKEN }}
+
+      - name: 📦 Install dependencies
+        run: yarn install
+
+      - name: 🚀 Create preview
+        uses: expo/expo-github-action/preview@v8
+        with:
+          command: eas update --auto

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -15,7 +15,7 @@ jobs:
       - name: 🏗 Setup EAS
         uses: expo/expo-github-action@v8
         with:
-          expo-version: latest
+          expo-version: 6.3.7
           token: ${{ secrets.EXPO_TOKEN }}
 
       - name: 📦 Install dependencies

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -15,7 +15,8 @@ jobs:
       - name: 🏗 Setup EAS
         uses: expo/expo-github-action@v8
         with:
-          expo-version: 6.3.7
+          eas-version: latest
+          expo-version: latest
           token: ${{ secrets.EXPO_TOKEN }}
 
       - name: 📦 Install dependencies


### PR DESCRIPTION
The repo was a nice find. I really like the patterns you and your team have put together here. 

I figured I would contribute back to your project. I created a GH Action based off of https://github.com/expo/expo-github-action. It also double checks the app can be built. Feel free to use if you wish.

When a user creates a Pull Request, the GH Action will create a preview build which can be downloaded via Expo Go for testing purposes. In order to get this action to work, one has to:
1. Create **expo token** described here: https://github.com/expo/expo-github-action#create-new-eas-update-on-push-to-main
2. Adjust **Actions** -> "Workflow permissions" in the repo settings to: "Read and Write permissions". Alternatively, you can add in those rights within the GH Action itself. 

Working GH Action and example after updating dependencies: https://github.com/michaelachrisco/recipes-app-react-native/pull/2 

Thanks again for the example project!